### PR TITLE
Using scopes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
 FROM semtech/mu-javascript-template:1.9.1
 LABEL maintainer="info@redpencil.io"
+
+ENV DEFAULT_MU_AUTH_SCOPE="http://services.semantic.works/complaint-form-email-converter-service"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ database for forms that have not been converted as a failover mechanism.
 
 ## Installation
 
-### Docker-compose snippet
-
 To add the service to your stack, add the following snippet to
 `docker-compose.yml`:
 

--- a/README.md
+++ b/README.md
@@ -52,27 +52,46 @@ Optionally, you can put the following snippet in the `delta-notifier` config:
 
 ```
 
-### Environment variables
+## Scopes
+
+This service uses scope support from the new `mu-authorization` /
+`sparql-parser` and no longer uses `mu-auth-sudo`. The default URI used by this
+service for scoping is
+
+```
+http://services.semantic.works/complaint-form-email-converter-service
+```
+
+as configured in the `Dockerfile`. This can be overriden via an environment
+variable. Use this URI for scoping to the correct graphs for the subjects of
+types:
+
+```turtle
+<http://mu.semte.ch/vocabularies/ext/ComplaintForm>
+<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>
+<http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Email>
+<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>
+<http://open-services.net/ns/core#Error>
+```
+
+See [the documentation on
+scoping](https://github.com/mu-semtech/sparql-parser#define-access-rights-for-specific-services)
+for more information.
+
+## Environment variables
 
 * `COMPLAINT_FORM_CRON_PATTERN`: <em>(optional, default: '0 * * * *' (= every
   hour))</em> Frequency of the cron job for scanning unconverted forms.
-* `COMPLAINT_FORM_GRAPH`: <em>(optional, default:
-  'http://mu.semte.ch/graphs/public')</em> The graph to query the Complaint
-  Form data from.
-* `FILE_GRAPH`: <em>(optional, default:
-  'http://mu.semte.ch/graphs/public')</em>
-* `EMAIL_GRAPH`: <em>(optional, default:
-  'http://mu.semte.ch/graphs/system/email')</em> The graph to store the
-  converted emails to.
 * `EMAIL_FROM_ADDRESS_TO_COMPLAINER`: <em>(optional, default:
   'noreply-binnenland@vlaanderen.be')</em>
 * `EMAIL_FROM_ADDRESS_TO_ABB`: <em>(optional, default:
   'noreply@lblod.info')</em>
 * `EMAIL_TO_ADDRESS`: <em>(optional, default: 'binnenland@vlaanderen.be')</em>
+* `DEFAULT_MU_AUTH_SCOPE`: <em>(optional, default:
+  'http://services.semantic.works/complaint-form-email-converter-service')</em>
+  URI for scoping in `mu-authorization` / `sparql-parser`.
 * `CREATOR`: <em>(optional, default:
   'http://lblod.data.gift/services/complaint-form-email-converter-service')</em>
   The URI for this service that will be linked to in error messages.
-* `ERROR_GRAPH`: <em>(optional, default:
-  'http://mu.semte.ch/graphs/error')</em> The graph in which to store errors.
 * `ERROR_BASE`: <em>(optional, default: 'http://data.lblod.info/errors/')</em>
   The base for URIs of errors.

--- a/app.js
+++ b/app.js
@@ -35,18 +35,14 @@ app.post('/delta', async function (req, res) {
 
 async function fetchAndConvertComplaintForms() {
   try {
-    const forms = await support.fetchFormsToBeConverted(env.complaintFormGraph);
+    const forms = await support.fetchFormsToBeConverted();
     if (!forms.length) console.log('No forms found that need to be converted');
     else console.log(`Found ${forms.length} forms to convert`);
 
     for (const form of forms) {
       try {
         console.log(`Fetching attachments for form ${form.uuid}`);
-        const attachments = await support.fetchFormAttachments(
-          env.complaintFormGraph,
-          env.fileGraph,
-          form.uuid,
-        );
+        const attachments = await support.fetchFormAttachments(form.uuid);
 
         console.log(`Creating emails for form ${form.uuid}`);
         const senderEmail = support.createSenderEmail(
@@ -62,30 +58,12 @@ async function fetchAndConvertComplaintForms() {
         );
 
         console.log(`Inserting emails to mailbox "${env.mailbox}"`);
-        await support.setEmailToMailbox(
-          senderEmail,
-          env.emailGraph,
-          env.mailbox,
-        );
-        await support.setEmailToMailbox(
-          receiverEmail,
-          env.emailGraph,
-          env.mailbox,
-        );
+        await support.setEmailToMailbox(senderEmail, env.mailbox);
+        await support.setEmailToMailbox(receiverEmail, env.mailbox);
 
         console.log(`Setting form ${form.uuid} to "converted"`);
-        await support.setFormAsConverted(
-          env.complaintFormGraph,
-          env.emailGraph,
-          form.uuid,
-          senderEmail.uuid,
-        );
-        await support.setFormAsConverted(
-          env.complaintFormGraph,
-          env.emailGraph,
-          form.uuid,
-          receiverEmail.uuid,
-        );
+        await support.setFormAsConverted(form.uuid, senderEmail.uuid);
+        await support.setFormAsConverted(form.uuid, receiverEmail.uuid);
 
         console.log(`End of processing form ${form.uuid}`);
       } catch (formError) {

--- a/env.js
+++ b/env.js
@@ -4,18 +4,6 @@ export const cronFrequency = envvar
   .get('COMPLAINT_FORM_CRON_PATTERN')
   .default('0 * * * *')
   .asString();
-export const complaintFormGraph = envvar
-  .get('COMPLAINT_FORM_GRAPH')
-  .default('http://mu.semte.ch/graphs/public')
-  .asString();
-export const emailGraph = envvar
-  .get('EMAIL_GRAPH')
-  .default('http://mu.semte.ch/graphs/system/email')
-  .asString();
-export const fileGraph = envvar
-  .get('FILE_GRAPH')
-  .default('http://mu.semte.ch/graphs/public')
-  .asString();
 export const fromAddressToComplainer = envvar
   .get('EMAIL_FROM_ADDRESS_TO_COMPLAINER')
   .default('noreply-binnenland@vlaanderen.be')
@@ -35,10 +23,6 @@ export const creator = envvar
   .default(
     'http://lblod.data.gift/services/complaint-form-email-converter-service',
   )
-  .asString();
-export const errorGraph = envvar
-  .get('ERROR_GRAPH')
-  .default('http://mu.semte.ch/graphs/error')
   .asString();
 export const errorBase = envvar
   .get('ERROR_BASE')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@lblod/mu-auth-sudo": "^1.1.0",
         "cron": "^4.4.0",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
@@ -283,22 +282,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@lblod/mu-auth-sudo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-1.1.0.tgz",
-      "integrity": "sha512-bJFVmyEZKHMk0dUs/1V6Qv9QNf9asIkliy7DN/TE6wxqDxcaUt5LyuRWzDGLvVJHwHkz+jK/eHp1krv0JCN0/A==",
-      "license": "MIT",
-      "dependencies": {
-        "digest-fetch": "^3.1.1",
-        "env-var": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "express-http-context": "~1.2.4"
-      }
-    },
     "node_modules/@pkgr/core": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
@@ -310,37 +293,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cls-hooked": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.9.tgz",
-      "integrity": "sha512-CMtHMz6Q/dkfcHarq9nioXH8BDPP+v5xvd+N90lBQ2bdmu06UvnLDqxTKoOJzz4SzIwb/x9i4UXGAAcnUDuIvg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/esrecurse": {
@@ -357,39 +309,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -402,70 +321,6 @@
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
       "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -514,30 +369,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -558,30 +395,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
       }
     },
     "node_modules/concat-map": {
@@ -621,15 +434,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/date-fns": {
@@ -675,28 +479,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/digest-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-3.1.1.tgz",
-      "integrity": "sha512-sfMKKDctvDUTljFnqTBeDl/20vZtKKNZ3XQleht2j3Ky1xuQLuvE9lT+Fvp3EZxJHwAk6RXeEEL4DCmKDSd8xA==",
-      "license": "ISC",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "js-sha256": "^0.9.0",
-        "js-sha512": "^0.8.0",
-        "md5": "^2.3.0"
-      }
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/env-var": {
       "version": "7.5.0",
@@ -1002,24 +784,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/express-http-context": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/express-http-context/-/express-http-context-1.2.5.tgz",
-      "integrity": "sha512-3wH4zvH7hkD/b0EJfAM7fafMzPqr7tKqWaVXJrEt6GH+U1a0WykIjoFY3pJbAke9Z78q6znz1Cpgm+Q5VsQsmw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/cls-hooked": "^4.2.1",
-        "@types/express": "^4.16.0",
-        "cls-hooked": "^4.2.2"
-      },
-      "engines": {
-        "node": ">=8.0.0 <10.0.0 || >=10.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/skonves/express-http-context?sponsor=1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1162,12 +926,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1197,18 +955,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-      "license": "MIT"
-    },
-    "node_modules/js-sha512": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
-      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
@@ -1301,17 +1047,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/minimatch": {
@@ -1483,16 +1218,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1515,20 +1240,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -1571,13 +1282,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "main": "app.js",
   "dependencies": {
-    "@lblod/mu-auth-sudo": "^1.1.0",
     "cron": "^4.4.0",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",

--- a/support.js
+++ b/support.js
@@ -1,4 +1,3 @@
-import * as mas from '@lblod/mu-auth-sudo';
 import * as mu from 'mu';
 import * as env from './env';
 import { v4 as uuid } from 'uuid';
@@ -37,7 +36,7 @@ function parseResult(result) {
  * Retrieve forms wating to be converted to emails
  */
 export async function fetchFormsToBeConverted(complaintFormGraph) {
-  const result = await mas.querySudo(`
+  const result = await mu.query(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX schema: <http://schema.org/>
@@ -45,45 +44,44 @@ export async function fetchFormsToBeConverted(complaintFormGraph) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX core: <http://mu.semte.ch/vocabularies/core/>
     PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     SELECT ?complaintForm ?uuid ?name ?contactPersonName ?street ?houseNumber ?addressComplement ?locality ?postalCode ?telephone ?senderEmail ?content ?created
     WHERE {
-      GRAPH ${mu.sparqlEscapeUri(complaintFormGraph)} {
-        ?complaintForm
-          a ext:ComplaintForm ;
-          core:uuid ?uuid ;
-          foaf:name ?name ;
-          schema:streetAddress ?street ;
-          schema:postOfficeBoxNumber ?houseNumber ;
-          schema:addressLocality ?locality ;
-          schema:postalCode ?postalCode ;
-          schema:email ?senderEmail ;
-          ext:content ?content ;
-          dct:created ?created ;
-          adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> .
+      ?complaintForm
+        rdf:type ext:ComplaintForm ;
+        core:uuid ?uuid ;
+        foaf:name ?name ;
+        schema:streetAddress ?street ;
+        schema:postOfficeBoxNumber ?houseNumber ;
+        schema:addressLocality ?locality ;
+        schema:postalCode ?postalCode ;
+        schema:email ?senderEmail ;
+        ext:content ?content ;
+        dct:created ?created ;
+        adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> .
 
-        BIND('-' as ?defaultContactPersonName)
-        OPTIONAL { ?complaintForm ext:personName ?optionalContactPersonName . }
-        BIND(
-          coalesce(
-            ?optionalContactPersonName,
-            ?defaultContactPersonName)
-          as ?contactPersonName)
+      BIND('-' as ?defaultContactPersonName)
+      OPTIONAL { ?complaintForm ext:personName ?optionalContactPersonName . }
+      BIND(
+        coalesce(
+          ?optionalContactPersonName,
+          ?defaultContactPersonName)
+        as ?contactPersonName)
 
-        BIND('-' as ?defaultAddressComplement).
-        OPTIONAL { ?complaintForm ext:addressComplement ?optionalAddressComplement . }
-        BIND(
-          coalesce(
-            ?optionalAddressComplement,
-            ?defaultAddressComplement)
-          as ?addressComplement).
+      BIND('-' as ?defaultAddressComplement).
+      OPTIONAL { ?complaintForm ext:addressComplement ?optionalAddressComplement . }
+      BIND(
+        coalesce(
+          ?optionalAddressComplement,
+          ?defaultAddressComplement)
+        as ?addressComplement).
 
-        BIND('-' as ?defaultTelephone).
-        OPTIONAL { ?complaintForm schema:telephone ?optionalTelephone . }
-        BIND(coalesce(?optionalTelephone, ?defaultTelephone) as ?telephone)
+      BIND('-' as ?defaultTelephone).
+      OPTIONAL { ?complaintForm schema:telephone ?optionalTelephone . }
+      BIND(coalesce(?optionalTelephone, ?defaultTelephone) as ?telephone)
 
-        FILTER NOT EXISTS { ?complaintForm ext:isConvertedIntoEmail ?email . }
-      }
+      FILTER NOT EXISTS { ?complaintForm ext:isConvertedIntoEmail ?email . }
     }
   `);
   return parseResult(result);
@@ -97,7 +95,7 @@ export async function fetchFormAttachments(
   fileGraph,
   formUuid,
 ) {
-  const result = await mas.querySudo(`
+  const result = await mu.query(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX schema: <http://schema.org/>
@@ -107,24 +105,23 @@ export async function fetchFormAttachments(
     PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
     PREFIX dcterms: <http://purl.org/dc/terms/>
     PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     SELECT ?file ?uuid ?filename ?format ?size
     WHERE {
-      GRAPH ${mu.sparqlEscapeUri(complaintFormGraph)} {
-        ?complaintForm
-          a ext:ComplaintForm ;
-          core:uuid ${mu.sparqlEscapeString(formUuid)} ;
-          nmo:hasAttachment ?attachment .
-      }
-      GRAPH ${mu.sparqlEscapeUri(fileGraph)} {
-        ?attachment
-          nfo:fileName ?filename ;
-          core:uuid ?uuid .
-        ?file
-          nie:dataSource ?attachment ;
-          dcterms:format ?format ;
-          nfo:fileSize ?size .
-      }
+      ?complaintForm
+        rdf:type ext:ComplaintForm ;
+        core:uuid ${mu.sparqlEscapeString(formUuid)} ;
+        nmo:hasAttachment ?attachment .
+      ?attachment
+        rdf:type nfo:FileDataObject ;
+        nfo:fileName ?filename ;
+        core:uuid ?uuid .
+      ?file
+        rdf:type nfo:FileDataObject ;
+        nie:dataSource ?attachment ;
+        dcterms:format ?format ;
+        nfo:fileSize ?size .
     }
   `);
   return parseResult(result);
@@ -157,17 +154,18 @@ export function createReceiverEmail(form, attachments, fromAddress, toAddress) {
  */
 export async function setEmailToMailbox(email, emailGraph, mailbox) {
   const sendDate = new Date();
-  return mas.updateSudo(`
+  return mu.update(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
     PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
     PREFIX core: <http://mu.semte.ch/vocabularies/core/>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     INSERT {
-      GRAPH ${mu.sparqlEscapeUri(emailGraph)} {
+      GRAPH <http://mu.semte.ch/graphs/application> {
         ${mu.sparqlEscapeUri(`http://data.lblod.info/id/emails/${email.uuid}`)}
-          a nmo:Email ;
+          rdf:type nmo:Email ;
           core:uuid ${mu.sparqlEscapeString(email.uuid)} ;
           nmo:messageFrom ${mu.sparqlEscapeString(email.from)} ;
           nmo:emailTo ${mu.sparqlEscapeString(email.to)} ;
@@ -180,11 +178,9 @@ export async function setEmailToMailbox(email, emailGraph, mailbox) {
       }
     }
     WHERE {
-      GRAPH ${mu.sparqlEscapeUri(emailGraph)} {
-        ?mailfolder
-          a nfo:Folder ;
-          nie:title ${mu.sparqlEscapeString(mailbox)} .
-      }
+      ?mailfolder
+        rdf:type nfo:Folder ;
+        nie:title ${mu.sparqlEscapeString(mailbox)} .
     }`);
 }
 
@@ -197,28 +193,25 @@ export async function setFormAsConverted(
   formUuid,
   emailUuid,
 ) {
-  return mas.updateSudo(`
+  return mu.update(`
     PREFIX schema: <http://schema.org/>
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
     INSERT {
-      GRAPH ${mu.sparqlEscapeUri(complaintFormGraph)} {
+      GRAPH <http://mu.semte.ch/graphs/application> {
         ?form ext:isConvertedIntoEmail ?email .
       }
     }
     WHERE {
-      GRAPH ${mu.sparqlEscapeUri(emailGraph)} {
-        ?email
-          a nmo:Email ;
-          core:uuid ${mu.sparqlEscapeString(emailUuid)} .
-      }
-      GRAPH ${mu.sparqlEscapeUri(complaintFormGraph)} {
-        ?form
-          a ext:ComplaintForm ;
-          core:uuid ${mu.sparqlEscapeString(formUuid)} .
-      }
+      ?email
+        rdf:type nmo:Email ;
+        core:uuid ${mu.sparqlEscapeString(emailUuid)} .
+      ?form
+        rdf:type ext:ComplaintForm ;
+        core:uuid ${mu.sparqlEscapeString(formUuid)} .
     }
   `);
 }
@@ -244,20 +237,18 @@ export async function sendErrorAlert(message, detail, reference) {
     PREFIX oslc: <http://open-services.net/ns/core#>
 
     INSERT DATA {
-      GRAPH ${mu.sparqlEscapeUri(env.errorGraph)} {
-        ${mu.sparqlEscapeUri(uri)}
-          rdf:type oslc:Error ;
-          mu:uuid ${mu.sparqlEscapeString(id)} ;
-          dct:subject ${mu.sparqlEscapeString(subject)} ;
-          oslc:message ${mu.sparqlEscapeString(message)} ;
-          dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
-          dct:creator ${mu.sparqlEscapeUri(env.creator)} .
-        ${referenceTriple}
-        ${detailTriple}
-      }
+      ${mu.sparqlEscapeUri(uri)}
+        rdf:type oslc:Error ;
+        mu:uuid ${mu.sparqlEscapeString(id)} ;
+        dct:subject ${mu.sparqlEscapeString(subject)} ;
+        oslc:message ${mu.sparqlEscapeString(message)} ;
+        dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
+        dct:creator ${mu.sparqlEscapeUri(env.creator)} .
+      ${referenceTriple}
+      ${detailTriple}
     }`;
   try {
-    await mas.updateSudo(insertErrorQuery);
+    await mu.update(insertErrorQuery);
     return uri;
   } catch (e) {
     console.error(

--- a/support.js
+++ b/support.js
@@ -35,7 +35,7 @@ function parseResult(result) {
 /**
  * Retrieve forms wating to be converted to emails
  */
-export async function fetchFormsToBeConverted(complaintFormGraph) {
+export async function fetchFormsToBeConverted() {
   const result = await mu.query(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -90,11 +90,7 @@ export async function fetchFormsToBeConverted(complaintFormGraph) {
 /**
  * Retrieve the attachments of a form
  */
-export async function fetchFormAttachments(
-  complaintFormGraph,
-  fileGraph,
-  formUuid,
-) {
+export async function fetchFormAttachments(formUuid) {
   const result = await mu.query(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -152,7 +148,7 @@ export function createReceiverEmail(form, attachments, fromAddress, toAddress) {
 /**
  * Set emails to mailbox
  */
-export async function setEmailToMailbox(email, emailGraph, mailbox) {
+export async function setEmailToMailbox(email, mailbox) {
   const sendDate = new Date();
   return mu.update(`
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
@@ -187,12 +183,7 @@ export async function setEmailToMailbox(email, emailGraph, mailbox) {
 /**
  * Set the form as converted to avoid re-converting it indefinitely
  */
-export async function setFormAsConverted(
-  complaintFormGraph,
-  emailGraph,
-  formUuid,
-  emailUuid,
-) {
+export async function setFormAsConverted(formUuid, emailUuid) {
   return mu.update(`
     PREFIX schema: <http://schema.org/>
     PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>


### PR DESCRIPTION
**[DL-7425]**

Re-implemented all queries to not use `mu-auth-sudo` and removed the dependency on that package. A default scope has been added that is used by the new `mu-javascript-template` to 'scope' requests to a certain privilege level in the new `sparql-parser` \ `mu-authorization`. Requests now go through the full `mu-authorization` config and data is dispatched to the correct graphs by `mu-authorization`, so there is no need to set them in the queries. When needed, we use the a dummy application graph to keep the queries syntactically valid.

Review in parallel with https://github.com/lblod/app-complaint-form/pull/16